### PR TITLE
Support Asset folder overrides for preprocessing on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 Cargo.lock
+.idea/
 
 debug.pem
 embedded.mobileprovision

--- a/apk/src/lib.rs
+++ b/apk/src/lib.rs
@@ -81,7 +81,7 @@ impl Apk {
         let file_name = asset
             .file_name()
             .context("Asset must have file_name component")?;
-        let dest = Path::new("assets").join(file_name);
+        let dest = Path::new(self.manifest.assets_folder.take().unwrap().as_str()).join(file_name);
         if asset.is_dir() {
             tracing::info!("Embedding asset directory `{}`", asset.display());
             self.zip.add_directory(asset, &dest, opts)

--- a/apk/src/manifest.rs
+++ b/apk/src/manifest.rs
@@ -33,6 +33,8 @@ pub struct AndroidManifest {
     pub uses_permission: Vec<Permission>,
     #[serde(default)]
     pub application: Application,
+    #[serde(default)]
+    pub assets_folder: Option<String>,
 }
 
 impl Default for AndroidManifest {
@@ -50,6 +52,7 @@ impl Default for AndroidManifest {
             compile_sdk_version_codename: Default::default(),
             platform_build_version_code: Default::default(),
             platform_build_version_name: Default::default(),
+            assets_folder: Some("assets".to_string())
         }
     }
 }

--- a/apk/src/manifest.rs
+++ b/apk/src/manifest.rs
@@ -52,7 +52,7 @@ impl Default for AndroidManifest {
             compile_sdk_version_codename: Default::default(),
             platform_build_version_code: Default::default(),
             platform_build_version_name: Default::default(),
-            assets_folder: Some("assets".to_string())
+            assets_folder: Some("assets".to_string()),
         }
     }
 }

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -295,7 +295,9 @@ impl CargoBuild {
             target_sdk_version
         );
         self.use_ld("lld");
-        self.add_link_arg("--target=aarch64-linux-android");
+        if let Some(triple) = self.triple {
+            self.add_link_arg(&format!("--target={}", triple));
+        }
         self.add_link_arg(&format!("-B{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", sdk_lib_dir.display()));
         self.add_link_arg(&format!("-L{}", lib_dir.display()));

--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -63,6 +63,7 @@ pub fn build(env: &BuildEnv, out: &Path) -> Result<()> {
     let min_sdk = manifest.sdk.min_sdk_version.take().unwrap();
     let version_code = manifest.version_code.take().unwrap();
     let version_name = manifest.version_name.take().unwrap();
+    let assets_folder = manifest.assets_folder.take().unwrap();
 
     manifest.compile_sdk_version = None;
     manifest.compile_sdk_version_codename = None;
@@ -101,7 +102,7 @@ pub fn build(env: &BuildEnv, out: &Path) -> Result<()> {
                 }}
                 sourceSets {{
                     main {{
-                        assets.srcDirs = ['../../../../../../assets']
+                        assets.srcDirs = ['../../../../../../{assets_folder}']
                     }}
                 }}
                 externalNativeBuild {{
@@ -120,6 +121,7 @@ pub fn build(env: &BuildEnv, out: &Path) -> Result<()> {
         version_code = version_code,
         version_name = version_name,
         dependencies = dependencies,
+        assets_folder = assets_folder,
     );
 
     if let Some(icon_path) = env.icon.as_ref() {


### PR DESCRIPTION
Adds an 'assets-folder' field to the manifest to work with asset-preprocessing - contains latest changes from xbuild base repo as well

Note: Also need to configure the asset plugin to look in 'assets' for preprocessed assets
![image](https://github.com/NiklasEi/xbuild/assets/77391373/cc851288-6f5f-4df2-8214-8f5764c52c8b)

And add the 'Default' sub dir in the manifest asset_folder path:

![image](https://github.com/NiklasEi/xbuild/assets/77391373/b0bc0f2c-5954-47fa-b8f3-223b2741d9d5)


